### PR TITLE
Fixed prunedStringClone, improvements on collectSync and NetworkTransmiter.

### DIFF
--- a/src/network/NetworkTransmitter.js
+++ b/src/network/NetworkTransmitter.js
@@ -11,8 +11,6 @@ export default class NetworkTransmitter {
 
         this.registeredEvents = [];
 
-        this.payload = [];
-
         this.serializer.registerClass(NetworkedEventCollection);
 
         this.registerNetworkedEventFactory('objectUpdate', {
@@ -42,6 +40,8 @@ export default class NetworkTransmitter {
                 fullUpdate: { type: Serializer.TYPES.UINT8 }
             }
         });
+
+        this.networkedEventCollection = new NetworkedEventCollection();
     }
 
     registerNetworkedEventFactory(eventName, options) {
@@ -66,17 +66,16 @@ export default class NetworkTransmitter {
         }
 
         let stagedNetworkedEvent = this.registeredEvents[eventName].create(payload);
-        this.payload.push(stagedNetworkedEvent);
+        this.networkedEventCollection.events.push(stagedNetworkedEvent);
 
         return stagedNetworkedEvent;
     }
 
     serializePayload() {
-        if (this.payload.length === 0)
+        if (this.networkedEventCollection.events.length === 0)
             return null;
 
-        let networkedEventCollection = new NetworkedEventCollection(this.payload);
-        let dataBuffer = networkedEventCollection.serialize(this.serializer);
+        let dataBuffer = this.networkedEventCollection.serialize(this.serializer);
 
         return dataBuffer;
     }
@@ -86,7 +85,7 @@ export default class NetworkTransmitter {
     }
 
     clearPayload() {
-        this.payload = [];
+        this.networkedEventCollection.events = [];
     }
 
 }

--- a/src/network/NetworkedEventCollection.js
+++ b/src/network/NetworkedEventCollection.js
@@ -17,7 +17,7 @@ export default class NetworkedEventCollection extends Serializable {
 
     constructor(events) {
         super();
-        this.events = events;
+        this.events = events || [];
     }
 
 }

--- a/src/serialize/Serializable.js
+++ b/src/serialize/Serializable.js
@@ -120,7 +120,7 @@ export default class Serializable {
         let isString = p => netScheme[p].type === Serializer.TYPES.STRING;
         let hasChanged = p => prevObject[p] !== this[p];
         let changedStrings = Object.keys(netScheme).filter(isString).filter(hasChanged);
-        if (!changedStrings) return this;
+        if (changedStrings.length == 0) return this;
 
         // build a clone with pruned strings
         let prunedCopy = new this.constructor(null, { id: null });

--- a/src/syncStrategies/SyncStrategy.js
+++ b/src/syncStrategies/SyncStrategy.js
@@ -35,33 +35,33 @@ export default class SyncStrategy {
         }
 
         // build new sync object
-        let lastSync = this.lastSync = {};
-        lastSync.stepCount = e.stepCount;
+        let lastSync = this.lastSync = {
+            stepCount: e.stepCount,
+            syncObjects: {},
+            syncSteps: {}
+        };
 
-        // keep a reference of events by object id
-        lastSync.syncObjects = {};
         e.syncEvents.forEach(sEvent => {
-            let o = sEvent.objectInstance;
-            if (!o) return;
-            if (!lastSync.syncObjects[o.id]) {
-                lastSync.syncObjects[o.id] = [];
+
+            // keep a reference of events by object id
+            if (sEvent.objectInstance){
+                let objectId = sEvent.objectInstance.id;
+                if (!lastSync.syncObjects[objectId]) lastSync.syncObjects[objectId] = [];
+                lastSync.syncObjects[objectId].push(sEvent);
             }
-            lastSync.syncObjects[o.id].push(sEvent);
+
+            // keep a reference of events by step
+            let stepCount = sEvent.stepCount,
+                eventName = this.serializer.getClassName(sEvent.classId);
+
+            if (!lastSync.syncSteps[stepCount]) lastSync.syncSteps[stepCount] = {};
+            if (!lastSync.syncSteps[stepCount][eventName]) lastSync.syncSteps[stepCount][eventName] = [];
+            lastSync.syncSteps[stepCount][eventName].push(sEvent);
         });
 
-        // keep a reference of events by step
-        lastSync.syncSteps = {};
-        e.syncEvents.forEach(sEvent => {
-
-            // add an entry for this step and event-name
-            if (!lastSync.syncSteps[sEvent.stepCount]) lastSync.syncSteps[sEvent.stepCount] = {};
-            if (!lastSync.syncSteps[sEvent.stepCount][sEvent.eventName]) lastSync.syncSteps[sEvent.stepCount][sEvent.eventName] = [];
-            lastSync.syncSteps[sEvent.stepCount][sEvent.eventName].push(sEvent);
-        });
-
-        let objCount = (Object.keys(lastSync.syncObjects)).length;
         let eventCount = e.syncEvents.length;
+        let objCount = (Object.keys(lastSync.syncObjects)).length;
         let stepCount = (Object.keys(lastSync.syncSteps)).length;
-        this.gameEngine.trace.debug(() => `sync contains ${objCount} objects ${eventCount} events ${stepCount} steps`);
+        this.gameEngine.trace.debug(`sync contains ${objCount} objects ${eventCount} events ${stepCount} steps`);
     }
 }

--- a/src/syncStrategies/SyncStrategy.js
+++ b/src/syncStrategies/SyncStrategy.js
@@ -52,7 +52,7 @@ export default class SyncStrategy {
 
             // keep a reference of events by step
             let stepCount = sEvent.stepCount,
-                eventName = this.serializer.getClassName(sEvent.classId);
+                eventName = sEvent.eventName;
 
             if (!lastSync.syncSteps[stepCount]) lastSync.syncSteps[stepCount] = {};
             if (!lastSync.syncSteps[stepCount][eventName]) lastSync.syncSteps[stepCount][eventName] = [];

--- a/src/syncStrategies/SyncStrategy.js
+++ b/src/syncStrategies/SyncStrategy.js
@@ -62,6 +62,6 @@ export default class SyncStrategy {
         let eventCount = e.syncEvents.length;
         let objCount = (Object.keys(lastSync.syncObjects)).length;
         let stepCount = (Object.keys(lastSync.syncSteps)).length;
-        this.gameEngine.trace.debug(`sync contains ${objCount} objects ${eventCount} events ${stepCount} steps`);
+        this.gameEngine.trace.debug(() => `sync contains ${objCount} objects ${eventCount} events ${stepCount} steps`);
     }
 }


### PR DESCRIPTION
Little fixes moved to develop branch from #69 

- Serializable.prunedStringClone ever builds a new instance .
- ExtrapolateStrategy.collectSync loops twice the objects .
- NetworkTransmiter build a NetworkedEventCollection all syncs and pass the payload .