### PR TITLE
Updated brute collision detection to be more versatile

### DIFF
--- a/src/physics/SimplePhysics/BruteForceCollisionDetection.js
+++ b/src/physics/SimplePhysics/BruteForceCollisionDetection.js
@@ -37,7 +37,6 @@ export default class BruteForceCollisionDetection {
 
     init(options) {
         this.gameEngine = options.gameEngine;
-        this.once = true
     }
 
     findCollision(o1, o2) {

--- a/src/physics/SimplePhysics/BruteForceCollisionDetection.js
+++ b/src/physics/SimplePhysics/BruteForceCollisionDetection.js
@@ -4,19 +4,35 @@ let differenceVector = new TwoVector();
 // The collision detection of SimplePhysicsEngine is a brute-force approach
 export default class BruteForceCollisionDetection {
 
+    // I would eventually like to change it so auto resolve
+    // allows for object pushing (an array of what objects to push)
+    
     constructor(options) {
         this.options = Object.assign({
-            autoResolve: true
+            limitCollisionTo: [],
+            hardCollide: [],
+            ignore: [],
+            ignorePairs: []
         }, options);
+        
+        // Ensure arrays were submitted
+        if(!Array.isArray(this.options.limitCollisionTo)) { console.log('Invalid limitCollisionTo value - must be array'); return }
+        if(!Array.isArray(this.options.hardCollide)) { console.log('Invalid hardCollide value - must be array'); return }
+        if(!Array.isArray(this.options.ignore)) { console.log('Invalid ignore value - must be array'); return }
+        if(!Array.isArray(this.options.ignorePairs)) { console.log('Invalid ignorePairs value - must be array'); return }
+
+        // Turn ignore pairs into map
+        this.options.ignorePairs = new Map(this.options.ignorePairs)
+
         this.collisionPairs = {};
     }
 
     init(options) {
         this.gameEngine = options.gameEngine;
+        this.once = true
     }
 
     findCollision(o1, o2) {
-
         // static objects don't collide
         if (o1.isStatic && o2.isStatic)
             return false;
@@ -42,56 +58,57 @@ export default class BruteForceCollisionDetection {
             o2Box.yMin > o1Box.yMax)
             return false;
 
-        if (!this.options.autoResolve)
-            return true;
+        // only auto resolve with static objects (static w/ non static)
+        if(this.options.hardCollide.includes(o1.constructor.name) || this.options.hardCollide.includes(o2.constructor.name)) {
 
-        // need to auto-resolve
-        let shiftY1 = o2Box.yMax - o1Box.yMin;
-        let shiftY2 = o1Box.yMax - o2Box.yMin;
-        let shiftX1 = o2Box.xMax - o1Box.xMin;
-        let shiftX2 = o1Box.xMax - o2Box.xMin;
-        let smallestYShift = Math.min(Math.abs(shiftY1), Math.abs(shiftY2));
-        let smallestXShift = Math.min(Math.abs(shiftX1), Math.abs(shiftX2));
+            // need to auto-resolve
+            let shiftY1 = o2Box.yMax - o1Box.yMin;
+            let shiftY2 = o1Box.yMax - o2Box.yMin;
+            let shiftX1 = o2Box.xMax - o1Box.xMin;
+            let shiftX2 = o1Box.xMax - o2Box.xMin;
+            let smallestYShift = Math.min(Math.abs(shiftY1), Math.abs(shiftY2));
+            let smallestXShift = Math.min(Math.abs(shiftX1), Math.abs(shiftX2));
 
-        // choose to apply the smallest shift which solves the collision
-        if (smallestYShift < smallestXShift) {
-            if (o1Box.yMin > o2Box.yMin && o1Box.yMin < o2Box.yMax) {
-                if (o2.isStatic) o1.position.y += shiftY1;
-                else if (o1.isStatic) o2.position.y -= shiftY1;
-                else {
-                    o1.position.y += shiftY1 / 2;
-                    o2.position.y -= shiftY1 / 2;
+            // choose to apply the smallest shift which solves the collision
+            if (smallestYShift < smallestXShift) {
+                if (o1Box.yMin > o2Box.yMin && o1Box.yMin < o2Box.yMax) {
+                    if (o2.isStatic) o1.position.y += shiftY1;
+                    else if (o1.isStatic) o2.position.y -= shiftY1;
+                    else {
+                        o1.position.y += shiftY1 / 2;
+                        o2.position.y -= shiftY1 / 2;
+                    }
+                } else if (o1Box.yMax > o2Box.yMin && o1Box.yMax < o2Box.yMax) {
+                    if (o2.isStatic) o1.position.y -= shiftY2;
+                    else if (o1.isStatic) o2.position.y += shiftY2;
+                    else {
+                        o1.position.y -= shiftY2 / 2;
+                        o2.position.y += shiftY2 / 2;
+                    }
                 }
-            } else if (o1Box.yMax > o2Box.yMin && o1Box.yMax < o2Box.yMax) {
-                if (o2.isStatic) o1.position.y -= shiftY2;
-                else if (o1.isStatic) o2.position.y += shiftY2;
-                else {
-                    o1.position.y -= shiftY2 / 2;
-                    o2.position.y += shiftY2 / 2;
+                o1.velocity.y = 0;
+                o2.velocity.y = 0;
+            } else {
+                if (o1Box.xMin > o2Box.xMin && o1Box.xMin < o2Box.xMax) {
+                    if (o2.isStatic) o1.position.x += shiftX1;
+                    else if (o1.isStatic) o2.position.x -= shiftX1;
+                    else {
+                        o1.position.x += shiftX1 / 2;
+                        o2.position.x -= shiftX1 / 2;
+                    }
+                } else if (o1Box.xMax > o2Box.xMin && o1Box.xMax < o2Box.xMax) {
+                    if (o2.isStatic) o1.position.x -= shiftX2;
+                    else if (o1.isStatic) o2.position.x += shiftX2;
+                    else {
+                        o1.position.x -= shiftX2 / 2;
+                        o2.position.x += shiftX2 / 2;
+                    }
                 }
+                o1.velocity.x = 0;
+                o2.velocity.x = 0;
             }
-            o1.velocity.y = 0;
-            o2.velocity.y = 0;
-        } else {
-            if (o1Box.xMin > o2Box.xMin && o1Box.xMin < o2Box.xMax) {
-                if (o2.isStatic) o1.position.x += shiftX1;
-                else if (o1.isStatic) o2.position.x -= shiftX1;
-                else {
-                    o1.position.x += shiftX1 / 2;
-                    o2.position.x -= shiftX1 / 2;
-                }
-            } else if (o1Box.xMax > o2Box.xMin && o1Box.xMax < o2Box.xMax) {
-                if (o2.isStatic) o1.position.x -= shiftX2;
-                else if (o1.isStatic) o2.position.x += shiftX2;
-                else {
-                    o1.position.x -= shiftX2 / 2;
-                    o2.position.x += shiftX2 / 2;
-                }
-            }
-            o1.velocity.x = 0;
-            o2.velocity.x = 0;
         }
-
+    
         return true;
     }
 
@@ -109,6 +126,33 @@ export default class BruteForceCollisionDetection {
             if (!(pairId in this.collisionPairs)) {
                 this.collisionPairs[pairId] = true;
                 this.gameEngine.emit('collisionStart', { o1, o2 });
+                
+                // Limit Collision To
+                if(this.options.limitCollisionTo.length && !this.options.limitCollisionTo.includes(o1.constructor.name) && !this.options.limitCollisionTo.includes(o2.constructor.name)) return 2
+
+                // Ignore
+                if(this.options.ignore.includes(o1.constructor.name) || this.options.ignore.includes(o2.constructor.name)) return 2
+
+                // Ignore Pairs
+                if(Array.isArray(this.options.ignorePairs.get(o1.constructor.name))) {
+                    this.options.ignorePairs.get(o1.constructor.name).forEach((item)=>{
+                        if(item == o1.constructor.name) return 3
+                    })
+                } else {
+                    if(this.options.ignorePairs.get(o1.constructor.name) == o1.constructor.name) return 2
+                }
+
+                // Trigger collision function
+                if(o1.collidedWith) o1.collidedWith(o2)
+                if(o2.collidedWith) o2.collidedWith(o1)
+
+                console.log(o1.constructor.name + ' collided with ' + o2.constructor.name)
+
+                // Release collision on object
+                setTimeout(() => {
+                    this.gameEngine.emit('collisionStop', { o1, o2 });
+                    delete this.collisionPairs[pairId];
+                }, 200);
             }
         } else if (pairId in this.collisionPairs) {
             this.gameEngine.emit('collisionStop', { o1, o2 });

--- a/src/physics/SimplePhysics/BruteForceCollisionDetection.js
+++ b/src/physics/SimplePhysics/BruteForceCollisionDetection.js
@@ -66,9 +66,9 @@ export default class BruteForceCollisionDetection {
             o2Box.yMin > o1Box.yMax)
             return false;
 
-        // only auto resolve with static objects (static w/ non static)
+        // Conditions for hardCollision
         if((this.options.hardCollision.limitCollisionTo.includes(o1.constructor.name) || this.options.hardCollision.limitCollisionTo.includes(o2.constructor.name)) && 
-        (!this.options.hardCollision.ignore.includes(o1.constructor.name) || !this.options.hardCollision.ignore.includes(o2.constructor.name))) {
+        (!this.options.hardCollision.ignore.includes(o1.constructor.name) && !this.options.hardCollision.ignore.includes(o2.constructor.name))) {
 
             // Ignore Pairs
             if(Array.isArray(this.options.hardCollision.ignorePairs.get(o1.constructor.name))) {


### PR DESCRIPTION
This change allows for the following configurations when setting up the physics engine:
```

        this.physicsEngine = new SimplePhysicsEngine({
            gravity: new TwoVector(0, 0.05),
            collisions: { 
                type: 'bruteForce', 
                limitCollisionTo: ['Player'],
                hardCollide: ['Wolf'],
                ignore: ['Minotaur'],
                ignorePairs: [
                    ['Player', 'Player']
                ]
            },
            gameEngine: this
        });
```
* limitCollisionTo - Sets which dynamic objects collision should affect (all if empty)
* hardCollide - Specifies which dynamic objects hard collide (platforms, floors, etc), everything else will "soft collide" trigger a collided with method on both objects. Ex: `if(o1.collidedWith) o1.collidedWith(o2)`
* ignore - Ignores collision with this dynamic object
* ignorePairs - Ignores collision between these two dynamic objects.
