### PR TITLE
bindKey with inputOptions for sendInput

### DIFF
--- a/src/controls/KeyboardControls.js
+++ b/src/controls/KeyboardControls.js
@@ -199,8 +199,18 @@ class KeyboardControls {
 
                     // handle repeat press
                     if (this.boundKeys[keyName].options.repeat || this.keyState[keyName].count == 0) {
+
+                        // callback to get live parameters if function
+                        let parameters = this.boundKeys[keyName].parameters;
+                        if (typeof parameters === "function") {
+                            parameters = parameters();
+                        }
+
                         // todo movement is probably redundant
-                        this.clientEngine.sendInput(this.boundKeys[keyName].actionName, { movement: true });
+                        let inputOptions = Object.assign({
+                            movement: true
+                        }, parameters || {});
+                        this.clientEngine.sendInput(this.boundKeys[keyName].actionName, inputOptions);
                         this.keyState[keyName].count++;
                     }
                 }
@@ -226,8 +236,10 @@ class KeyboardControls {
      * @param {String} actionName - the event name
      * @param {Object} options - options object
      * @param {Boolean} options.repeat - if set to true, an event continues to be sent on each game step, while the key is pressed
+     * @param {Object/Function} parameters - parameters (or function to get parameters) to be sent to
+     *                                       the server with sendInput as the inputOptions
      */
-    bindKey(keys, actionName, options) {
+    bindKey(keys, actionName, options, parameters) {
         if (!Array.isArray(keys)) keys = [keys];
 
         let keyOptions = Object.assign({
@@ -235,7 +247,7 @@ class KeyboardControls {
         }, options);
 
         keys.forEach(keyName => {
-            this.boundKeys[keyName] = { actionName, options: keyOptions };
+            this.boundKeys[keyName] = { actionName, options: keyOptions, parameters: parameters };
         });
     }
 


### PR DESCRIPTION
Add a new parameter to the bindKey method to specify inputOptions.  I have a case where more than one piece of information was needed in a call to sendInput, which is easy to achieve by directly calling it in an event handler but to bind that to a keypress meant manually repeating lots of the code already in KeyboardControls class.

This implementation allows for either the data to be passed, or a callback which allows for more generic handling.

Have kept the movement:true inputOption as I am unaware if that is actually needed internally but this could be a good time to remove that is somebody who knows more than me knows if it is needed.